### PR TITLE
Cors

### DIFF
--- a/src/main/java/org/example/hanmo/config/WebMvcConfig.java
+++ b/src/main/java/org/example/hanmo/config/WebMvcConfig.java
@@ -33,8 +33,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
                         "https://hanmo-front-r22cegd8m-leegyeonghwans-projects.vercel.app",
                         "http://hanmo-front-r22cegd8m-leegyeonghwans-projects.vercel.app",
                         "https://hanmo-front-git-lee-leegyeonghwans-projects.vercel.app",
-                        "http://hanmo-front-git-lee-leegyeonghwans-projects.vercel.app"
-                )
+                        "http://hanmo-front-git-lee-leegyeonghwans-projects.vercel.app")
                 .exposedHeaders("temptoken")
                 .allowedHeaders("*")
                 .allowedMethods("*")

--- a/src/main/java/org/example/hanmo/config/WebMvcConfig.java
+++ b/src/main/java/org/example/hanmo/config/WebMvcConfig.java
@@ -29,7 +29,12 @@ public class WebMvcConfig implements WebMvcConfigurer {
                         "https://hanmo.store",
                         "https://www.hanmo.store",
                         "http://hanmo.store",
-                        "http://www.hanmo.store")
+                        "http://www.hanmo.store",
+                        "https://hanmo-front-r22cegd8m-leegyeonghwans-projects.vercel.app",
+                        "http://hanmo-front-r22cegd8m-leegyeonghwans-projects.vercel.app",
+                        "https://hanmo-front-git-lee-leegyeonghwans-projects.vercel.app",
+                        "http://hanmo-front-git-lee-leegyeonghwans-projects.vercel.app"
+                )
                 .exposedHeaders("temptoken")
                 .allowedHeaders("*")
                 .allowedMethods("*")

--- a/src/main/java/org/example/hanmo/domain/UserEntity.java
+++ b/src/main/java/org/example/hanmo/domain/UserEntity.java
@@ -46,6 +46,9 @@ public class UserEntity extends BaseTimeEntity { // user의 기본 정보
     @Column(name = "student_number", length = 20, unique = true)
     private String studentNumber;
 
+    @Column(name = "nickname_changed", nullable = false)
+    private Boolean nicknameChanged = false; // 기본값 false 닉네임 1회변경 한번 바꾸면 true로
+
     @Column(name = "status", length = 20)
     private UserStatus userStatus; // 대기중, 매칭완료, 탈퇴 그룹의 status와는 다름
 
@@ -70,5 +73,13 @@ public class UserEntity extends BaseTimeEntity { // user의 기본 정보
 
     public void setNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public boolean isNicknameChanged() {
+        return nicknameChanged != null ? nicknameChanged : false;
+    }
+
+    public void setNicknameChanged(boolean nicknameChanged) {
+        this.nicknameChanged = nicknameChanged;
     }
 }

--- a/src/main/java/org/example/hanmo/domain/enums/Department.java
+++ b/src/main/java/org/example/hanmo/domain/enums/Department.java
@@ -9,23 +9,23 @@ import lombok.Getter;
 
 @Getter
 public enum Department {
-    SINHAK(1, "신학과"),
-    MEDIA(2, "미디어영상광고학과"),
-    MANAGEMENT(3, "경영학과"),
-    POLICE(4, "경찰행정학과"),
-    TOURISM(5, "국제관광학과"),
+    SINHAK(1, "신학"),
+    MEDIA(2, "미광"),
+    MANAGEMENT(3, "경영"),
+    POLICE(4, "경행"),
+    TOURISM(5, "국관"),
     ENGLISH(6, "영어학과"),
     CHINESE(7, "중국어학과"),
-    COMPUTER(8, "컴퓨터공학과"),
-    SECURITY(9, "융합보안학과"),
-    NURSING(10, "간호학과"),
-    SOCIAL_WELFARE(11, "사회복지학과"),
-    MUSIC(12, "음악학과"),
-    PERFORMING_ARTS(13, "공연예술학과"),
-    VISUAL_DESIGN(14, "시각정보디자인학과"),
-    INTERIOR_DESIGN(15, "실내건축디자인학과"),
-    FASHION_DESIGN(16, "섬유패션디자인학과"),
-    FREE_MAJOR(17, "자유전공학부");
+    COMPUTER(8, "컴공"),
+    SECURITY(9, "융보"),
+    NURSING(10, "간호"),
+    SOCIAL_WELFARE(11, "사복"),
+    MUSIC(12, "음악"),
+    PERFORMING_ARTS(13, "공예"),
+    VISUAL_DESIGN(14, "시디"),
+    INTERIOR_DESIGN(15, "실건디"),
+    FASHION_DESIGN(16, "섬패디"),
+    FREE_MAJOR(17, "자유");
 
     private final int code;
     private final String departmentType;

--- a/src/main/java/org/example/hanmo/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/UserServiceImpl.java
@@ -56,7 +56,6 @@ public class UserServiceImpl implements UserService {
 
         UserValidate.setUniqueRandomNicknameIfNeeded(user, true, userRepository);
 
-        redisTempRepository.deleteTempToken(tempToken);
         user = userRepository.save(user);
         return new UserSignUpResponseDto(user.getNickname(), user.getPhoneNumber());
     }

--- a/src/main/java/org/example/hanmo/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/UserServiceImpl.java
@@ -57,6 +57,7 @@ public class UserServiceImpl implements UserService {
         UserValidate.setUniqueRandomNicknameIfNeeded(user, true, userRepository);
 
         user = userRepository.save(user);
+        redisTempRepository.deleteTempToken(tempToken);
         return new UserSignUpResponseDto(user.getNickname(), user.getPhoneNumber());
     }
 

--- a/src/main/java/org/example/hanmo/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/UserServiceImpl.java
@@ -50,14 +50,16 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserSignUpResponseDto changeNickname(String tempToken) {
         // 임시 토큰으로부터 전화번호를 검증 및 조회합니다.
-        String phoneNumber =
-                UserValidate.validatePhoneNumberByTempToken(tempToken, redisTempRepository);
+        String phoneNumber = UserValidate.validatePhoneNumberByTempToken(tempToken, redisTempRepository);
         UserEntity user = UserValidate.getUserByPhoneNumber(phoneNumber, userRepository);
+        // 닉네임 이미 변경 된 경우 예외처리
+        UserValidate.validateNicknameNotChanged(user);
 
         UserValidate.setUniqueRandomNicknameIfNeeded(user, true, userRepository);
+        user.setNicknameChanged(true);
 
         user = userRepository.save(user);
-        redisTempRepository.deleteTempToken(tempToken);
+        //        redisTempRepository.deleteTempToken(tempToken);
         return new UserSignUpResponseDto(user.getNickname(), user.getPhoneNumber());
     }
 

--- a/src/main/java/org/example/hanmo/vaildate/UserValidate.java
+++ b/src/main/java/org/example/hanmo/vaildate/UserValidate.java
@@ -70,4 +70,11 @@ public class UserValidate {
                                 new NotFoundException(
                                         "사용자를 찾을 수 없습니다.", ErrorCode.NOT_FOUND_EXCEPTION));
     }
+
+    public static void validateNicknameNotChanged(UserEntity user) {
+        if (user.isNicknameChanged()) {
+            throw new BadRequestException(
+                    "이미 닉네임이 변경되었습니다.", ErrorCode.DUPLICATE_NICKNAME_EXCEPTION);
+        }
+    }
 }


### PR DESCRIPTION
1. 프론트엔드 배포주소 corsAdd, 
2. 학과 enum 수정 ex)컴퓨터공학과 -> 컴공, 닉네임 길이가 너무 길어 밑으로 내려간다는 의견이 있어
줄임말로 사용하게 되었습니다. 
3. 닉네임 변경, 변경시 임시토큰을 바로 삭제하면 다음 페이지에 닉네임을 불러 올 수 없어, 
삭제 코드는 주석처리, 대신 nickname_changed라는 컬럼을 boolean타입으로 넣어 0,1로 상태가 1로 이미 변경 한 경우는
다시 변경 할 수 없도록 처리했습니다.