### PR TITLE
feat: 매칭 취소 예외 수정

### DIFF
--- a/src/main/java/org/example/hanmo/domain/enums/Department.java
+++ b/src/main/java/org/example/hanmo/domain/enums/Department.java
@@ -26,7 +26,7 @@ public enum Department {
   INTERIOR_DESIGN(15, "실건디"),
   FASHION_DESIGN(16, "섬패디"),
   FREE_MAJOR(17, "자유"),
-  IT_MAJOR(18,"IT");
+  IT_MAJOR(18, "IT");
 
   private final int code;
   private final String departmentType;

--- a/src/main/java/org/example/hanmo/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/MatchingServiceImpl.java
@@ -339,20 +339,17 @@ public class MatchingServiceImpl implements MatchingService {
             .collect(Collectors.toList());
 
     return new MatchingResultResponse(matchingGroup.getMatchingType(), users);
-
-    //    return matchingGroup.getUsers().stream()
-    //        .map(
-    //            matchedUser ->
-    //                new UserProfileResponseDto(
-    //                    matchedUser.getNickname(), matchedUser.getName(),
-    // matchedUser.getInstagramId()))
-    //        .collect(Collectors.toList());
   }
 
   // 매칭 취소
   @Transactional
   public void cancelMatching(String tempToken) {
     UserEntity user = authValidate.validateTempToken(tempToken);
+
+    if (user.getUserStatus() == UserStatus.MATCHED) {
+      throw new MatchingException(
+          "이미 매칭이 완료된 상태이므로 매칭을 취소할 수 없습니다.", ErrorCode.USER_ALREADY_MATCHED);
+    }
 
     if (user.getUserStatus() != UserStatus.PENDING) {
       throw new MatchingException("매칭 대기 상태가 아니므로 취소할 수 없습니다.", ErrorCode.MATCHING_NOT_IN_PROGRESS);


### PR DESCRIPTION
* "MATCHED"인 사용자가 매칭 취소 시도할 경우, 이미 매칭이 완료된 상태이므로 매칭 취소 불가 예외 처리