### PR TITLE
feat: 매칭실패시 3시간후 REDIS키값과, 매칭상태,타입 NULL 설정

### DIFF
--- a/src/main/java/org/example/hanmo/redis/listener/KeyExpirationListener.java
+++ b/src/main/java/org/example/hanmo/redis/listener/KeyExpirationListener.java
@@ -1,0 +1,52 @@
+package org.example.hanmo.redis.listener;
+
+import java.util.List;
+import org.example.hanmo.domain.UserEntity;
+import org.example.hanmo.domain.enums.MatchingType;
+import org.example.hanmo.domain.enums.UserStatus;
+import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.redis.RedisWaitingRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class KeyExpirationListener extends KeyExpirationEventMessageListener {
+
+    private final UserRepository userRepository;
+    private final RedisWaitingRepository redisWaitingRepository;
+
+    @Autowired
+    public KeyExpirationListener(RedisMessageListenerContainer container, UserRepository userRepository, RedisWaitingRepository redisWaitingRepository) {
+        super(container);
+        this.userRepository = userRepository;
+        this.redisWaitingRepository = redisWaitingRepository;
+    }
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        // 만료된 키 문자열 (e.g., "ONE_TO_ONE" or "TWO_TO_TWO")
+        String expiredKey = message.toString();
+        MatchingType type;
+        try {
+            type = MatchingType.valueOf(expiredKey);
+        } catch (IllegalArgumentException e) {
+            // 매칭 관련 키가 아니면 즉시 종료
+            return;
+        }
+
+        List<UserEntity> users = userRepository.findAllByUserStatusAndMatchingType(UserStatus.PENDING, type);
+
+        // DB에서 해당 타입의 PENDING 상태 유저 목록 조회
+        for (UserEntity u : users) {
+            // 각 유저에 대해 Redis 리스트 제거 및 DB 롤백 수행
+            redisWaitingRepository.removeUserFromWaitingGroup(type, List.of(u.toRedisUserDto()));
+            u.setUserStatus(null);
+            u.setMatchingType(null);
+            userRepository.save(u);
+        }
+    }
+}

--- a/src/main/java/org/example/hanmo/repository/UserRepository.java
+++ b/src/main/java/org/example/hanmo/repository/UserRepository.java
@@ -10,8 +10,8 @@ import org.example.hanmo.domain.enums.UserStatus;
 import org.example.hanmo.domain.enums.WithdrawalStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import io.lettuce.core.dynamic.annotation.Param;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
   boolean existsByPhoneNumber(String phoneNumber);
@@ -33,9 +33,11 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
   Optional<UserEntity> findByIdAndUserStatus(Long id, UserStatus status);
 
   // 탈퇴한 지 3일이 지난 유저는 DB에서 삭제
-  List<UserEntity> findAllByWithdrawalStatusAndWithdrawalTimestampBefore(
-      WithdrawalStatus status, LocalDateTime cutoff);
+  List<UserEntity> findAllByWithdrawalStatusAndWithdrawalTimestampBefore(WithdrawalStatus status, LocalDateTime cutoff);
 
   @Query("SELECT u FROM UserEntity u WHERE u.matchingType = :matchingType")
   List<UserEntity> findAllByMatchingType(@Param("matchingType") MatchingType matchingType);
+
+  List<UserEntity> findAllByUserStatusAndMatchingType(UserStatus userStatus, MatchingType matchingType);
+
 }


### PR DESCRIPTION
매칭 대기 등록 시 Redis 리스트 키에 3시간 TTL 설정->애플리케이션 시작 시 notify-keyspace-events를 Ex로 활성화
->RedisMessageListenerContainer를 통해 expired 이벤트를 구독->만료된 키 감지 시 KeyExpirationListener 실행
->해당 매칭 타입의 PENDING 유저 조회
->Redis 대기 리스트 요소 제거
->DB의 userStatus 및 matchingType을 null로 초기화