### PR TITLE
Feature/chatting

### DIFF
--- a/src/main/java/org/example/hanmo/controller/AdminController.java
+++ b/src/main/java/org/example/hanmo/controller/AdminController.java
@@ -1,11 +1,15 @@
 package org.example.hanmo.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
+import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
 import org.example.hanmo.service.AdminService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/admin")
@@ -26,4 +30,21 @@ public class AdminController {
         String tempToken = adminService.loginAdmin(request);
         return ResponseEntity.ok().header("tempToken", tempToken).body("관리자 로그인 되었습니다.");
     }
+
+    @Operation(summary = "닉네임으로 사용자 검색 (최대 5개)")
+    @GetMapping("/users")
+    public ResponseEntity<List<AdminUserResponseDto>> searchUsers(HttpServletRequest request, @RequestParam String nickname) {
+        String tempToken = request.getHeader("tempToken");
+        List<AdminUserResponseDto> result = adminService.searchUsersByNickname(tempToken, nickname);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "닉네임으로 사용자 삭제 (관리자)")
+    @DeleteMapping("/users/{nickname}")
+    public ResponseEntity<String> deleteUser(HttpServletRequest request, @PathVariable String nickname) {
+        String tempToken = request.getHeader("tempToken");
+        adminService.deleteUserByNickname(tempToken, nickname);
+        return ResponseEntity.ok("입력하신 닉네임 : " + nickname +" 이 삭제 되었습니다.");
+    }
+
 }

--- a/src/main/java/org/example/hanmo/controller/test/TestDataController.java
+++ b/src/main/java/org/example/hanmo/controller/test/TestDataController.java
@@ -6,7 +6,7 @@ import org.example.hanmo.domain.UserEntity;
 import org.example.hanmo.domain.enums.MatchingType;
 import org.example.hanmo.dto.matching.request.RedisUserDto;
 import org.example.hanmo.redis.RedisWaitingRepository;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.springframework.web.bind.annotation.*;
 
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/org/example/hanmo/domain/UserEntity.java
+++ b/src/main/java/org/example/hanmo/domain/UserEntity.java
@@ -86,7 +86,7 @@ public class UserEntity extends BaseTimeEntity { // user의 기본 정보
   @Column(name = "gender_matching_type", length = 20)
   private GenderMatchingType genderMatchingType;
 
-  @ManyToOne
+  @ManyToOne(cascade = CascadeType.PERSIST)
   @JoinColumn(name = "matching_group_id")
   private MatchingGroupsEntity matchingGroup;
 

--- a/src/main/java/org/example/hanmo/dto/admin/response/AdminUserResponseDto.java
+++ b/src/main/java/org/example/hanmo/dto/admin/response/AdminUserResponseDto.java
@@ -1,0 +1,15 @@
+package org.example.hanmo.dto.admin.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminUserResponseDto {
+    private Long userId;
+    private String nickname;
+    private String name;
+    private String phoneNumber;
+    private String instagramId;
+    private String userRole;
+}

--- a/src/main/java/org/example/hanmo/redis/RedisWaitingRepository.java
+++ b/src/main/java/org/example/hanmo/redis/RedisWaitingRepository.java
@@ -4,12 +4,11 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.example.hanmo.domain.UserEntity;
-import org.example.hanmo.domain.enums.Gender;
 import org.example.hanmo.domain.enums.GenderMatchingType;
 import org.example.hanmo.domain.enums.MatchingType;
 import org.example.hanmo.domain.enums.UserStatus;
 import org.example.hanmo.dto.matching.request.RedisUserDto;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/org/example/hanmo/redis/listener/KeyExpirationListener.java
+++ b/src/main/java/org/example/hanmo/redis/listener/KeyExpirationListener.java
@@ -9,7 +9,7 @@ import org.example.hanmo.domain.enums.GenderMatchingType;
 import org.example.hanmo.domain.enums.MatchingType;
 import org.example.hanmo.domain.enums.UserStatus;
 import org.example.hanmo.redis.RedisWaitingRepository;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/example/hanmo/repository/user/UserRepository.java
+++ b/src/main/java/org/example/hanmo/repository/user/UserRepository.java
@@ -22,6 +22,8 @@ public interface UserRepository extends JpaRepository<UserEntity, Long>, UserRep
 
   Optional<UserEntity> findByPhoneNumber(String phoneNumber);
 
+  Optional<UserEntity> findByNickname(String nickname);
+
   Optional<UserEntity> findByPhoneNumberAndLoginId(String phoneNumber, String loginId);
 
   Optional<UserEntity> findByPhoneNumberAndStudentNumber(String phoneNumber, String studentNumber);

--- a/src/main/java/org/example/hanmo/repository/user/UserRepository.java
+++ b/src/main/java/org/example/hanmo/repository/user/UserRepository.java
@@ -1,4 +1,4 @@
-package org.example.hanmo.repository;
+package org.example.hanmo.repository.user;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,7 +13,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface UserRepository extends JpaRepository<UserEntity, Long> {
+public interface UserRepository extends JpaRepository<UserEntity, Long>, UserRepositoryCustom {
   boolean existsByPhoneNumber(String phoneNumber);
 
   boolean existsByNickname(String nickname);
@@ -46,4 +46,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 //  List<UserEntity> findAllByUserStatusAndMatchingType(UserStatus userStatus, MatchingType matchingType);
 
   List<UserEntity> findAllByUserStatusAndMatchingTypeAndGenderMatchingType(UserStatus userStatus, MatchingType matchingType, GenderMatchingType genderMatchingType);
+
+  void deleteByNickname(String nickname);
 }

--- a/src/main/java/org/example/hanmo/repository/user/UserRepositoryCustom.java
+++ b/src/main/java/org/example/hanmo/repository/user/UserRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.example.hanmo.repository.user;
+
+import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
+import java.util.List;
+
+public interface UserRepositoryCustom {
+
+    List<AdminUserResponseDto> searchUsersByNickname(String nickname);
+}

--- a/src/main/java/org/example/hanmo/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/org/example/hanmo/repository/user/UserRepositoryImpl.java
@@ -1,0 +1,46 @@
+package org.example.hanmo.repository.user;
+
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.hanmo.domain.QUserEntity;
+import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
+import org.example.hanmo.error.ErrorCode;
+import org.example.hanmo.error.exception.BadRequestException;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+    private static final long FIXED_LIMIT = 5;
+
+    @Override
+    public List<AdminUserResponseDto> searchUsersByNickname(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new BadRequestException("닉네임을 입력해주세요.", ErrorCode.BAD_REQUEST_EXCEPTION);
+        }
+
+        String kw = nickname.trim();
+        QUserEntity u = QUserEntity.userEntity;
+
+        return queryFactory
+                .select(Projections.constructor(
+                        AdminUserResponseDto.class,
+                        u.id,
+                        u.nickname,
+                        u.name,
+                        u.phoneNumber,
+                        u.instagramId,
+                        u.userRole.stringValue()
+                ))
+                .from(u)
+                .where(u.nickname.containsIgnoreCase(kw))
+                .orderBy(u.id.desc())
+                .limit(FIXED_LIMIT)
+                .fetch();
+    }
+}

--- a/src/main/java/org/example/hanmo/service/AdminService.java
+++ b/src/main/java/org/example/hanmo/service/AdminService.java
@@ -1,9 +1,15 @@
 package org.example.hanmo.service;
 
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
+import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
+
+import java.util.List;
 
 public interface AdminService {
     String loginAdmin(AdminRequestDto requestDto);
 
     void addAdminInfo(AdminRequestDto dto);
+    List<AdminUserResponseDto> searchUsersByNickname(String tempToken,String nickname);
+
+    void deleteUserByNickname(String tempToken,String nickname);
 }

--- a/src/main/java/org/example/hanmo/service/MatchingService.java
+++ b/src/main/java/org/example/hanmo/service/MatchingService.java
@@ -42,4 +42,6 @@ public interface MatchingService {
 
   // 매칭 취소
   void cancelMatching(String tempToken);
+
+  void cleanupAfterUserDeletion(String nickname);
 }

--- a/src/main/java/org/example/hanmo/service/impl/AdminServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/AdminServiceImpl.java
@@ -5,16 +5,22 @@ import org.apache.commons.lang3.StringUtils;
 import org.example.hanmo.domain.UserEntity;
 import org.example.hanmo.domain.enums.UserRole;
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
+import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
 import org.example.hanmo.error.ErrorCode;
 import org.example.hanmo.error.exception.BadRequestException;
+import org.example.hanmo.error.exception.ForbiddenException;
+import org.example.hanmo.error.exception.NotFoundException;
 import org.example.hanmo.redis.RedisTempRepository;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.example.hanmo.service.AdminService;
 import org.example.hanmo.vaildate.AdminValidate;
+import org.example.hanmo.vaildate.AuthValidate;
 import org.example.hanmo.vaildate.UserValidate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +30,7 @@ public class AdminServiceImpl implements AdminService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final RedisTempRepository redisTempRepository;
+    private final AuthValidate authValidate;
 
     @Override
     public String loginAdmin(AdminRequestDto dto) {
@@ -54,5 +61,31 @@ public class AdminServiceImpl implements AdminService {
         user.setLoginPw(passwordEncoder.encode(dto.getLoginPw()));
         // 5) 저장
         userRepository.save(user);
+    }
+
+    @Override
+    public List<AdminUserResponseDto> searchUsersByNickname(String tempToken, String nickname) {
+        // 관리자 인증
+        UserEntity admin = authValidate.validateTempToken(tempToken);
+        if (admin.getUserRole() != UserRole.ADMIN) {
+            throw new ForbiddenException("관리자 권한이 없습니다.", ErrorCode.FORBIDDEN_EXCEPTION);
+        }
+        // 검색 수행
+        return userRepository.searchUsersByNickname(nickname);
+    }
+
+    @Override
+    public void deleteUserByNickname(String tempToken, String nickname) {
+        // 관리자 인증
+        UserEntity admin = authValidate.validateTempToken(tempToken);
+        if (admin.getUserRole() != UserRole.ADMIN) {
+            throw new ForbiddenException("관리자 권한이 없습니다.", ErrorCode.FORBIDDEN_EXCEPTION);
+        }
+        // 사용자 조회 및 삭제
+        if (!userRepository.existsByNickname(nickname)) {
+            throw new NotFoundException("삭제할 사용자를 찾을 수 없습니다.", ErrorCode.NOT_FOUND_EXCEPTION);
+        }
+        // 삭제
+        userRepository.deleteByNickname(nickname);
     }
 }

--- a/src/main/java/org/example/hanmo/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/MatchingServiceImpl.java
@@ -18,7 +18,7 @@ import org.example.hanmo.error.exception.MatchingException;
 import org.example.hanmo.error.exception.NotFoundException;
 import org.example.hanmo.redis.RedisWaitingRepository;
 import org.example.hanmo.repository.MatchingGroupRepository;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.example.hanmo.service.MatchingService;
 import org.example.hanmo.vaildate.AuthValidate;
 import org.example.hanmo.vaildate.UserValidate;

--- a/src/main/java/org/example/hanmo/service/impl/SmsServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/SmsServiceImpl.java
@@ -2,7 +2,7 @@ package org.example.hanmo.service.impl;
 
 import org.example.hanmo.dto.sms.request.SmsRequestDto;
 import org.example.hanmo.redis.RedisSmsRepository;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.example.hanmo.service.SmsService;
 import org.example.hanmo.util.SmsCertificationUtil;
 import org.example.hanmo.vaildate.SmsValidate;

--- a/src/main/java/org/example/hanmo/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/UserServiceImpl.java
@@ -19,7 +19,7 @@ import org.example.hanmo.redis.RedisSmsRepository;
 import org.example.hanmo.redis.RedisTempRepository;
 import org.example.hanmo.redis.RedisWaitingRepository;
 import org.example.hanmo.repository.MatchingGroupRepository;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.example.hanmo.service.UserService;
 import org.example.hanmo.vaildate.AuthValidate;
 import org.example.hanmo.vaildate.SmsValidate;

--- a/src/main/java/org/example/hanmo/util/UserCleanupUtil.java
+++ b/src/main/java/org/example/hanmo/util/UserCleanupUtil.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import org.example.hanmo.domain.UserEntity;
 import org.example.hanmo.domain.enums.WithdrawalStatus;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/org/example/hanmo/vaildate/AdminValidate.java
+++ b/src/main/java/org/example/hanmo/vaildate/AdminValidate.java
@@ -6,7 +6,7 @@ import org.example.hanmo.domain.enums.UserRole;
 import org.example.hanmo.error.ErrorCode;
 import org.example.hanmo.error.exception.ForbiddenException;
 import org.example.hanmo.error.exception.NotFoundException;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/org/example/hanmo/vaildate/AdminValidate.java
+++ b/src/main/java/org/example/hanmo/vaildate/AdminValidate.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class AdminValidate {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthValidate authValidate;
     public UserEntity validateAdminLogin(String phoneNumber,String loginId,String loginPw){
         UserEntity admin = userRepository.findByPhoneNumberAndLoginId(phoneNumber, loginId).orElseThrow(() ->
                         new NotFoundException("관리자 정보를 찾을 수 없습니다.", ErrorCode.NOT_FOUND_EXCEPTION));
@@ -30,5 +31,12 @@ public class AdminValidate {
         }
 
         return admin;
+    }
+
+    public void verifyAdmin(String tempToken) {
+        UserEntity admin = authValidate.validateTempToken(tempToken);
+        if (admin.getUserRole() != UserRole.ADMIN) {
+            throw new ForbiddenException("관리자 권한이 없습니다.", ErrorCode.FORBIDDEN_EXCEPTION);
+        }
     }
 }

--- a/src/main/java/org/example/hanmo/vaildate/AuthValidate.java
+++ b/src/main/java/org/example/hanmo/vaildate/AuthValidate.java
@@ -5,7 +5,7 @@ import org.example.hanmo.error.ErrorCode;
 import org.example.hanmo.error.exception.NotFoundException;
 import org.example.hanmo.error.exception.TempTokenException;
 import org.example.hanmo.redis.RedisTempRepository;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/example/hanmo/vaildate/SmsValidate.java
+++ b/src/main/java/org/example/hanmo/vaildate/SmsValidate.java
@@ -6,7 +6,7 @@ import org.example.hanmo.error.ErrorCode;
 import org.example.hanmo.error.exception.AccountDeactivatedException;
 import org.example.hanmo.error.exception.SmsSendException;
 import org.example.hanmo.redis.RedisSmsRepository;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/example/hanmo/vaildate/UserValidate.java
+++ b/src/main/java/org/example/hanmo/vaildate/UserValidate.java
@@ -10,7 +10,7 @@ import org.example.hanmo.domain.enums.WithdrawalStatus;
 import org.example.hanmo.error.ErrorCode;
 import org.example.hanmo.error.exception.*;
 import org.example.hanmo.redis.RedisTempRepository;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.example.hanmo.util.RandomNicknameUtil;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;

--- a/src/test/java/org/example/hanmo/smsservice/SmsServiceTest.java
+++ b/src/test/java/org/example/hanmo/smsservice/SmsServiceTest.java
@@ -9,7 +9,7 @@ import org.example.hanmo.dto.sms.request.SmsRequestDto;
 import org.example.hanmo.error.ErrorCode;
 import org.example.hanmo.error.exception.SmsSendException;
 import org.example.hanmo.redis.RedisSmsRepository;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.example.hanmo.service.impl.SmsServiceImpl;
 import org.example.hanmo.util.SmsCertificationUtil;
 import org.example.hanmo.vaildate.SmsValidate;

--- a/src/test/java/org/example/hanmo/userservice/UserServiceTest.java
+++ b/src/test/java/org/example/hanmo/userservice/UserServiceTest.java
@@ -22,7 +22,7 @@ import org.example.hanmo.dto.user.response.UserProfileResponseDto;
 import org.example.hanmo.dto.user.response.UserSignUpResponseDto;
 import org.example.hanmo.redis.RedisSmsRepository;
 import org.example.hanmo.redis.RedisTempRepository;
-import org.example.hanmo.repository.UserRepository;
+import org.example.hanmo.repository.user.UserRepository;
 import org.example.hanmo.service.impl.UserServiceImpl;
 import org.example.hanmo.vaildate.AuthValidate;
 import org.example.hanmo.vaildate.SmsValidate;


### PR DESCRIPTION
어드민, 회원 조회 삭제로직 만들었습니다. 
1. 조회는 like %문으로 일부만 검색해도 단어 들어간 최신순 5명이 나오도록 했습니다.
2. 삭제는 , 닉네임으로 삭제하며 그 유저는 바로 삭제되고 그 유저가 매칭 그룹이나 팀원이 있을 경우 같이 속해있던 매칭그룹 인원들의
매칭 상태는 다 null로 변경됨 