### PR TITLE
feat: 오늘 매칭그룹 수 구현

### DIFF
--- a/src/main/java/org/example/hanmo/controller/AdminController.java
+++ b/src/main/java/org/example/hanmo/controller/AdminController.java
@@ -3,6 +3,7 @@ package org.example.hanmo.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.example.hanmo.dto.admin.date.DashboardStatsDto;
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
 import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
 import org.example.hanmo.service.AdminService;
@@ -18,21 +19,21 @@ public class AdminController {
     private final AdminService adminService;
 
     @Operation(summary = "관리자 추가 정보 입력")
-    @PutMapping("/signup/admin")
+    @PutMapping("/signup")
     public ResponseEntity<String> addAdminInfo(@RequestBody AdminRequestDto dto) {
         adminService.addAdminInfo(dto);
         return ResponseEntity.ok("추가 정보가 입력되었습니다.");
     }
 
     @Operation(summary = "관리자 로그인 (테스트용입니다. jwt나올 시 변경, 지금은 임시토큰)")
-    @PostMapping("/login/admin")
+    @PostMapping("/login")
     public ResponseEntity<String> loginAdmin(@RequestBody AdminRequestDto request) {
         String tempToken = adminService.loginAdmin(request);
         return ResponseEntity.ok().header("tempToken", tempToken).body("관리자 로그인 되었습니다.");
     }
 
     @Operation(summary = "닉네임으로 사용자 검색 (최대 5개)")
-    @GetMapping("/users")
+    @GetMapping("/search")
     public ResponseEntity<List<AdminUserResponseDto>> searchUsers(HttpServletRequest request, @RequestParam String nickname) {
         String tempToken = request.getHeader("tempToken");
         List<AdminUserResponseDto> result = adminService.searchUsersByNickname(tempToken, nickname);
@@ -40,11 +41,18 @@ public class AdminController {
     }
 
     @Operation(summary = "닉네임으로 사용자 삭제 (관리자)")
-    @DeleteMapping("/users/{nickname}")
+    @DeleteMapping("/{nickname}")
     public ResponseEntity<String> deleteUser(HttpServletRequest request, @PathVariable String nickname) {
         String tempToken = request.getHeader("tempToken");
         adminService.deleteUserByNickname(tempToken, nickname);
         return ResponseEntity.ok("입력하신 닉네임 : " + nickname +" 이 삭제 되었습니다.");
     }
 
+    @Operation(summary = "오늘 매칭된 그룹 수")
+    @GetMapping("/stats")
+    public ResponseEntity<DashboardStatsDto> getDashboardStats(HttpServletRequest request) {
+        String tempToken = request.getHeader("tempToken");
+        DashboardStatsDto stats = adminService.getDashboardStats(tempToken);
+        return ResponseEntity.ok(stats);
+    }
 }

--- a/src/main/java/org/example/hanmo/dto/admin/date/DashboardStatsDto.java
+++ b/src/main/java/org/example/hanmo/dto/admin/date/DashboardStatsDto.java
@@ -1,0 +1,10 @@
+package org.example.hanmo.dto.admin.date;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DashboardStatsDto {
+    private String todayMatchedGroupCount;
+}

--- a/src/main/java/org/example/hanmo/repository/MatchingGroupRepository.java
+++ b/src/main/java/org/example/hanmo/repository/MatchingGroupRepository.java
@@ -1,8 +1,17 @@
 package org.example.hanmo.repository;
 
 import org.example.hanmo.domain.MatchingGroupsEntity;
+import org.example.hanmo.domain.enums.GroupStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
 
 public interface MatchingGroupRepository extends JpaRepository<MatchingGroupsEntity, Long> {
   //    List<MatchingGroupsEntity> findByGroupId(Long groupId);
+
+    long countByGroupStatusAndCreateDateBetween(
+            GroupStatus groupStatus,
+            LocalDateTime fromInclusive,
+            LocalDateTime toExclusive
+    );
 }

--- a/src/main/java/org/example/hanmo/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/org/example/hanmo/repository/user/UserRepositoryImpl.java
@@ -16,7 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UserRepositoryImpl implements UserRepositoryCustom {
     private final JPAQueryFactory queryFactory;
-    private static final long FIXED_LIMIT = 5;
+    private static final long FIXED_LIMIT = 30;
 
     @Override
     public List<AdminUserResponseDto> searchUsersByNickname(String nickname) {

--- a/src/main/java/org/example/hanmo/service/AdminService.java
+++ b/src/main/java/org/example/hanmo/service/AdminService.java
@@ -1,5 +1,6 @@
 package org.example.hanmo.service;
 
+import org.example.hanmo.dto.admin.date.DashboardStatsDto;
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
 import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
 
@@ -12,4 +13,5 @@ public interface AdminService {
     List<AdminUserResponseDto> searchUsersByNickname(String tempToken,String nickname);
 
     void deleteUserByNickname(String tempToken,String nickname);
+    DashboardStatsDto getDashboardStats(String tempToken);
 }

--- a/src/main/java/org/example/hanmo/util/DateTimeUtil.java
+++ b/src/main/java/org/example/hanmo/util/DateTimeUtil.java
@@ -1,0 +1,18 @@
+package org.example.hanmo.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public class DateTimeUtil {
+
+    private DateTimeUtil() { }
+
+    public static LocalDateTime startOfToday(ZoneId zone) {
+        return LocalDate.now(zone).atStartOfDay();
+    }
+
+    public static LocalDateTime startOfTomorrow(ZoneId zone) {
+        return LocalDate.now(zone).plusDays(1).atStartOfDay();
+    }
+}


### PR DESCRIPTION
서울 시간 기준 00:00 ~ 다음날 00:00 까지의 하루 매칭수를 확인 가능 
나중에 날짜별 페이징으로 확인 가능하도록 설계 예정입니다.

유저 닉네임으로 검색 수를 5 -> 30으로 늘렸습니다. 