### PR TITLE
fix: 가입,그룹매칭 통계 DTO분리

### DIFF
--- a/src/main/java/org/example/hanmo/controller/AdminController.java
+++ b/src/main/java/org/example/hanmo/controller/AdminController.java
@@ -3,7 +3,8 @@ package org.example.hanmo.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.example.hanmo.dto.admin.date.DashboardStatsDto;
+import org.example.hanmo.dto.admin.date.DashboardSignUpDto;
+import org.example.hanmo.dto.admin.date.DashboardGroupDto;
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
 import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
 import org.example.hanmo.service.AdminService;
@@ -34,7 +35,7 @@ public class AdminController {
 
     @Operation(summary = "닉네임으로 사용자 검색 (최대 30개)",tags = {"관리자 기능"})
     @GetMapping("/search")
-    public ResponseEntity<List<AdminUserResponseDto>> searchUsers(HttpServletRequest request, @RequestParam String nickname) {
+    public ResponseEntity<List<AdminUserResponseDto>> searchUsers(HttpServletRequest request, @RequestParam(value = "nickname", required = false, defaultValue = "") String nickname) {
         String tempToken = request.getHeader("tempToken");
         List<AdminUserResponseDto> result = adminService.searchUsersByNickname(tempToken, nickname);
         return ResponseEntity.ok(result);
@@ -51,17 +52,17 @@ public class AdminController {
 
     @Operation(summary = "오늘 매칭된 그룹 수",tags = {"관리자 기능"})
     @GetMapping("/matching-count")
-    public ResponseEntity<DashboardStatsDto> getDashboardStats(HttpServletRequest request) {
+    public ResponseEntity<DashboardGroupDto> getDashboardStats(HttpServletRequest request) {
         String tempToken = request.getHeader("tempToken");
-        DashboardStatsDto matchingCount = adminService.getDashboardStats(tempToken);
+        DashboardGroupDto matchingCount = adminService.getDashboardStats(tempToken);
         return ResponseEntity.ok(matchingCount);
     }
 
     @Operation(summary = "오늘 가입한 회원 수",tags = {"관리자 기능"})
     @GetMapping("/signup-count")
-    public ResponseEntity<DashboardStatsDto> getTodaySignupStats(HttpServletRequest request) {
+    public ResponseEntity<DashboardSignUpDto> getTodaySignupStats(HttpServletRequest request) {
         String tempToken = request.getHeader("tempToken");
-        DashboardStatsDto signUpCount=adminService.getTodaySignupStats(tempToken);
+        DashboardSignUpDto signUpCount=adminService.getTodaySignupStats(tempToken);
         return ResponseEntity.ok(signUpCount);
     }
 }

--- a/src/main/java/org/example/hanmo/dto/admin/date/DashboardGroupDto.java
+++ b/src/main/java/org/example/hanmo/dto/admin/date/DashboardGroupDto.java
@@ -1,0 +1,10 @@
+package org.example.hanmo.dto.admin.date;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DashboardGroupDto {
+    private String todayMatchedGroupCount;
+}

--- a/src/main/java/org/example/hanmo/dto/admin/date/DashboardSignUpDto.java
+++ b/src/main/java/org/example/hanmo/dto/admin/date/DashboardSignUpDto.java
@@ -1,10 +1,11 @@
 package org.example.hanmo.dto.admin.date;
 
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class DashboardStatsDto {
-    private String todayMatchedGroupCount;
+public class DashboardSignUpDto {
+    private String todayMatchedSignUpCount;
 }

--- a/src/main/java/org/example/hanmo/service/AdminService.java
+++ b/src/main/java/org/example/hanmo/service/AdminService.java
@@ -1,6 +1,7 @@
 package org.example.hanmo.service;
 
-import org.example.hanmo.dto.admin.date.DashboardStatsDto;
+import org.example.hanmo.dto.admin.date.DashboardSignUpDto;
+import org.example.hanmo.dto.admin.date.DashboardGroupDto;
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
 import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
 
@@ -13,8 +14,8 @@ public interface AdminService {
     List<AdminUserResponseDto> searchUsersByNickname(String tempToken,String nickname);
 
     void deleteUserByNickname(String tempToken,String nickname);
-    DashboardStatsDto getDashboardStats(String tempToken);
+    DashboardGroupDto getDashboardStats(String tempToken);
 
-    DashboardStatsDto getTodaySignupStats(String tempToken);
+    DashboardSignUpDto getTodaySignupStats(String tempToken);
 
 }

--- a/src/main/java/org/example/hanmo/service/impl/AdminServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/AdminServiceImpl.java
@@ -5,7 +5,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.example.hanmo.domain.UserEntity;
 import org.example.hanmo.domain.enums.GroupStatus;
 import org.example.hanmo.domain.enums.UserRole;
-import org.example.hanmo.dto.admin.date.DashboardStatsDto;
+import org.example.hanmo.dto.admin.date.DashboardSignUpDto;
+import org.example.hanmo.dto.admin.date.DashboardGroupDto;
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
 import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
 import org.example.hanmo.error.ErrorCode;
@@ -88,7 +89,7 @@ public class AdminServiceImpl implements AdminService {
     }
 
     @Override
-    public DashboardStatsDto getDashboardStats(String tempToken) {
+    public DashboardGroupDto getDashboardStats(String tempToken) {
         adminValidate.verifyAdmin(tempToken);
         LocalDateTime start = DateTimeUtil.startOfToday(SEOUL);
         LocalDateTime end   = DateTimeUtil.startOfTomorrow(SEOUL);
@@ -96,16 +97,17 @@ public class AdminServiceImpl implements AdminService {
                 .countByGroupStatusAndCreateDateBetween(GroupStatus.MATCHED, start, end);
 
         String msg = String.format("오늘 매칭된 그룹 수는 %d팀 입니다.", count);
-        return new DashboardStatsDto(msg);
+        return new DashboardGroupDto(msg);
     }
 
     @Override
-    public DashboardStatsDto getTodaySignupStats(String tempToken) {
+    public DashboardSignUpDto getTodaySignupStats(String tempToken) {
+        adminValidate.verifyAdmin(tempToken);
         long signupCount = userRepository.countByCreateDateBetween(
                 DateTimeUtil.startOfToday(SEOUL),
                 DateTimeUtil.startOfTomorrow(SEOUL)
         );
         String signupMsg = String.format("오늘 가입한 회원 수는 %d명 입니다.", signupCount);
-        return new DashboardStatsDto(signupMsg);
+        return new DashboardSignUpDto(signupMsg);
     }
 }


### PR DESCRIPTION
가입과 그룹매칭 DTO가 같아 같은 메서드명으로 날라가서, DTO분리 했습니다.

유저 조회시 빈문자열로 검색시 최신 30명의 정보를 띄워놨습니다.
