### PR TITLE
Feature/chatting

### DIFF
--- a/src/main/java/org/example/hanmo/controller/AdminController.java
+++ b/src/main/java/org/example/hanmo/controller/AdminController.java
@@ -33,11 +33,11 @@ public class AdminController {
         return ResponseEntity.ok().header("tempToken", tempToken).body("관리자 로그인 되었습니다.");
     }
 
-    @Operation(summary = "닉네임으로 사용자 검색 (최대 30개)",tags = {"관리자 기능"})
+    @Operation(summary = "닉네임, 이름으로 사용자 검색 (최대 30개)",tags = {"관리자 기능"})
     @GetMapping("/search")
-    public ResponseEntity<List<AdminUserResponseDto>> searchUsers(HttpServletRequest request, @RequestParam(value = "nickname", required = false, defaultValue = "") String nickname) {
+    public ResponseEntity<List<AdminUserResponseDto>> searchUsers(HttpServletRequest request, @RequestParam(value = "nickname,name", required = false, defaultValue = "") String keyword) {
         String tempToken = request.getHeader("tempToken");
-        List<AdminUserResponseDto> result = adminService.searchUsersByNickname(tempToken, nickname);
+        List<AdminUserResponseDto> result = adminService.searchUsersByNickname(tempToken, keyword);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/org/example/hanmo/controller/AdminController.java
+++ b/src/main/java/org/example/hanmo/controller/AdminController.java
@@ -36,7 +36,7 @@ public class AdminController {
 
     @Operation(summary = "닉네임, 이름으로 사용자 검색 (최대 30개)",tags = {"관리자 기능"})
     @GetMapping("/search")
-    public ResponseEntity<List<AdminUserResponseDto>> searchUsers(HttpServletRequest request, @RequestParam(value = "nickname,name", required = false, defaultValue = "") String keyword) {
+    public ResponseEntity<List<AdminUserResponseDto>> searchUsers(HttpServletRequest request, @RequestParam(value = "keyword", required = false, defaultValue = "") String keyword) {
         String tempToken = request.getHeader("tempToken");
         List<AdminUserResponseDto> result = adminService.searchUsersByNickname(tempToken, keyword);
         return ResponseEntity.ok(result);

--- a/src/main/java/org/example/hanmo/controller/AdminController.java
+++ b/src/main/java/org/example/hanmo/controller/AdminController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.hanmo.dto.admin.date.DashboardSignUpDto;
 import org.example.hanmo.dto.admin.date.DashboardGroupDto;
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
+import org.example.hanmo.dto.admin.request.AdminRoleRequestDto;
 import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
 import org.example.hanmo.service.AdminService;
 import org.springframework.http.ResponseEntity;
@@ -64,5 +65,13 @@ public class AdminController {
         String tempToken = request.getHeader("tempToken");
         DashboardSignUpDto signUpCount=adminService.getTodaySignupStats(tempToken);
         return ResponseEntity.ok(signUpCount);
+    }
+
+    @Operation(summary = "사용자 권한 변경 (0=USER, 1=ADMIN)", tags = {"관리자 기능"})
+    @PutMapping("/role")
+    public ResponseEntity<String> changeUserRole(HttpServletRequest request, @RequestBody AdminRoleRequestDto dto) {
+        String tempToken = request.getHeader("tempToken");
+        adminService.changeUserRole(tempToken, dto.getUserId(), dto.getNewRole());
+        return ResponseEntity.ok("유저 "+dto.getUserId()+"번 의 등급이 "+ dto.getNewRole()+" 로 변경되었습니다.");
     }
 }

--- a/src/main/java/org/example/hanmo/domain/enums/UserRole.java
+++ b/src/main/java/org/example/hanmo/domain/enums/UserRole.java
@@ -1,8 +1,31 @@
 package org.example.hanmo.domain.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import org.example.hanmo.vaildate.EnumValidate;
+
+@Getter
 public enum UserRole {
 
-    USER,
-    ADMIN //어드민
-    //일반 유저
+    USER(0, "USER"),
+    ADMIN(1, "ADMIN");
+
+    private final int code;
+    private final String description;
+
+    UserRole(int code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    @JsonCreator
+    public static UserRole fromCode(Integer code) {
+        return EnumValidate.validateUserRole(code);
+    }
+
+    @JsonValue
+    public int toValue() {
+        return code;
+    }
 }

--- a/src/main/java/org/example/hanmo/dto/admin/request/AdminRoleRequestDto.java
+++ b/src/main/java/org/example/hanmo/dto/admin/request/AdminRoleRequestDto.java
@@ -1,0 +1,15 @@
+package org.example.hanmo.dto.admin.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.hanmo.domain.enums.UserRole;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminRoleRequestDto {
+    private Long userId;
+    private UserRole newRole;
+
+}

--- a/src/main/java/org/example/hanmo/dto/admin/response/AdminUserResponseDto.java
+++ b/src/main/java/org/example/hanmo/dto/admin/response/AdminUserResponseDto.java
@@ -2,6 +2,9 @@ package org.example.hanmo.dto.admin.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.example.hanmo.domain.enums.MatchingType;
+import org.example.hanmo.domain.enums.UserRole;
+import org.example.hanmo.domain.enums.UserStatus;
 
 @Getter
 @AllArgsConstructor
@@ -12,4 +15,7 @@ public class AdminUserResponseDto {
     private String phoneNumber;
     private String instagramId;
     private String userRole;
+    private UserStatus userStatus;
+    private Long matchingGroupId;
+    private MatchingType matchingType;
 }

--- a/src/main/java/org/example/hanmo/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/org/example/hanmo/repository/user/UserRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.example.hanmo.repository.user;
 
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +41,8 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 
         if (StringUtils.isNotBlank(nickname)) {
             String kw = nickname.trim();
-            query.where(u.nickname.containsIgnoreCase(kw));
+            BooleanExpression predicate = u.nickname.containsIgnoreCase(kw).or(u.name.containsIgnoreCase(kw));
+            query.where(predicate);
         }
         return query.fetch();
     }

--- a/src/main/java/org/example/hanmo/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/org/example/hanmo/repository/user/UserRepositoryImpl.java
@@ -33,7 +33,10 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                         u.name,
                         u.phoneNumber,
                         u.instagramId,
-                        u.userRole.stringValue()
+                        u.userRole.stringValue(),
+                        u.userStatus,
+                        u.matchingGroup.matchingGroupId,
+                        u.matchingType
                 ))
                 .from(u)
                 .orderBy(u.id.desc())

--- a/src/main/java/org/example/hanmo/service/AdminService.java
+++ b/src/main/java/org/example/hanmo/service/AdminService.java
@@ -1,5 +1,6 @@
 package org.example.hanmo.service;
 
+import org.example.hanmo.domain.enums.UserRole;
 import org.example.hanmo.dto.admin.date.DashboardSignUpDto;
 import org.example.hanmo.dto.admin.date.DashboardGroupDto;
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
@@ -17,5 +18,7 @@ public interface AdminService {
     DashboardGroupDto getDashboardStats(String tempToken);
 
     DashboardSignUpDto getTodaySignupStats(String tempToken);
+
+    void changeUserRole(String tempToken, Long userId, UserRole newRole);
 
 }

--- a/src/main/java/org/example/hanmo/service/AdminService.java
+++ b/src/main/java/org/example/hanmo/service/AdminService.java
@@ -12,7 +12,7 @@ public interface AdminService {
     String loginAdmin(AdminRequestDto requestDto);
 
     void addAdminInfo(AdminRequestDto dto);
-    List<AdminUserResponseDto> searchUsersByNickname(String tempToken,String nickname);
+    List<AdminUserResponseDto> searchUsersByNickname(String tempToken,String keyword);
 
     void deleteUserByNickname(String tempToken,String nickname);
     DashboardGroupDto getDashboardStats(String tempToken);

--- a/src/main/java/org/example/hanmo/service/impl/AdminServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/AdminServiceImpl.java
@@ -80,11 +80,9 @@ public class AdminServiceImpl implements AdminService {
     @Override
     public void deleteUserByNickname(String tempToken, String nickname) {
         adminValidate.verifyAdmin(tempToken);
-        UserEntity user = userRepository.findByNickname(nickname)
-                .orElseThrow(() -> new NotFoundException("삭제할 사용자를 찾을 수 없습니다.", ErrorCode.NOT_FOUND_EXCEPTION));
-
+        UserEntity user = UserValidate.getUserByNickname(nickname, userRepository);
         // 3) 매칭 관계 정리 (null 처리 및 그룹 삭제)
-        matchingService.cleanupAfterUserDeletion(nickname);
+        matchingService.cleanupAfterUserDeletion(user.getNickname());
         userRepository.delete(user);
     }
 
@@ -109,5 +107,13 @@ public class AdminServiceImpl implements AdminService {
         );
         String signupMsg = String.format("오늘 가입한 회원 수는 %d명 입니다.", signupCount);
         return new DashboardSignUpDto(signupMsg);
+    }
+
+    @Override
+    public void changeUserRole(String tempToken, Long userId, UserRole newRole) {
+        adminValidate.verifyAdmin(tempToken);
+        UserEntity target = UserValidate.getUserById(userId, userRepository);
+        target.setUserRole(newRole);
+        userRepository.save(target);
     }
 }

--- a/src/main/java/org/example/hanmo/vaildate/EnumValidate.java
+++ b/src/main/java/org/example/hanmo/vaildate/EnumValidate.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import org.example.hanmo.domain.enums.Department;
 import org.example.hanmo.domain.enums.Gender;
 import org.example.hanmo.domain.enums.Mbti;
+import org.example.hanmo.domain.enums.UserRole;
 import org.example.hanmo.error.ErrorCode;
 import org.example.hanmo.error.exception.BadRequestException;
 
@@ -41,6 +42,16 @@ public class EnumValidate {
             () ->
                 new BadRequestException(
                     "유효하지 않은 성별 코드: " + code, ErrorCode.INVALID_CODE_EXCEPTION));
+  }
+
+  public static UserRole validateUserRole(Integer code) {
+    int nonNull = requireNonNullCode(code, "사용자 역할");
+    return Arrays.stream(UserRole.values())
+            .filter(r -> r.getCode() == nonNull)
+            .findFirst()
+            .orElseThrow(() -> new BadRequestException(
+                    "유효하지 않은 UserRole 코드: " + code,
+                    ErrorCode.INVALID_CODE_EXCEPTION));
   }
 
   private static Integer requireNonNullCode(Integer code, String type) {

--- a/src/main/java/org/example/hanmo/vaildate/UserValidate.java
+++ b/src/main/java/org/example/hanmo/vaildate/UserValidate.java
@@ -146,4 +146,18 @@ public class UserValidate {
           "아직 하루가 지나지않았습니다. 다시 매칭이 불가능합니다.", ErrorCode.TOO_EARLY_FOR_REMATCHING);
     }
   }
+
+  public static UserEntity getUserById(Long userId, UserRepository userRepository) {
+    return userRepository.findById(userId)
+            .orElseThrow(() -> new NotFoundException(
+                    "사용자를 찾을 수 없습니다.",
+                    ErrorCode.NOT_FOUND_EXCEPTION));
+  }
+
+  public static UserEntity getUserByNickname(String nickname, UserRepository userRepository) {
+    return userRepository.findByNickname(nickname)
+            .orElseThrow(() -> new NotFoundException(
+                    "삭제할 사용자를 찾을 수 없습니다.",
+                    ErrorCode.NOT_FOUND_EXCEPTION));
+  }
 }


### PR DESCRIPTION
유저 조회를 닉네임으로만 검색하도록 구현했었는데, 이름도 필요 할 거 같아서 닉네임 + 이름 검색으로 로직을 변경했습니다.

유저 검색창에서 바로 어드민이나 유저로 승급,하락 할 수 있도록 로직 추가 했습니다.