### PR TITLE
feat: 매칭대기중인 유저 확인 로직 구현 타입별 PENDING상태 조회

### DIFF
--- a/src/main/java/org/example/hanmo/controller/AdminController.java
+++ b/src/main/java/org/example/hanmo/controller/AdminController.java
@@ -5,10 +5,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.example.hanmo.dto.admin.date.DashboardSignUpDto;
 import org.example.hanmo.dto.admin.date.DashboardGroupDto;
+import org.example.hanmo.dto.admin.date.QueueInfoResponseDto;
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
 import org.example.hanmo.dto.admin.request.AdminRoleRequestDto;
 import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
 import org.example.hanmo.service.AdminService;
+import org.example.hanmo.service.MatchingService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +21,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AdminController {
     private final AdminService adminService;
+    private final MatchingService matchingService;
 
     @Operation(summary = "관리자 추가 정보 입력",tags = {"관리자 로그인"})
     @PutMapping("/signup")
@@ -73,5 +76,13 @@ public class AdminController {
         String tempToken = request.getHeader("tempToken");
         adminService.changeUserRole(tempToken, dto.getUserId(), dto.getNewRole());
         return ResponseEntity.ok("유저 "+dto.getUserId()+"번 의 등급이 "+ dto.getNewRole()+" 로 변경되었습니다.");
+    }
+
+    @Operation(summary = "매칭 대기열 현황 조회", tags = {"관리자 기능"})
+    @GetMapping("/queue-status")
+    public ResponseEntity<List<QueueInfoResponseDto>> getQueueStatuses(HttpServletRequest request) {
+        String tempToken = request.getHeader("tempToken");
+        List<QueueInfoResponseDto> statuses = adminService.getQueueStatuses(tempToken);
+        return ResponseEntity.ok(statuses);
     }
 }

--- a/src/main/java/org/example/hanmo/dto/admin/date/QueueInfoResponseDto.java
+++ b/src/main/java/org/example/hanmo/dto/admin/date/QueueInfoResponseDto.java
@@ -1,0 +1,14 @@
+package org.example.hanmo.dto.admin.date;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.hanmo.domain.enums.GenderMatchingType;
+import org.example.hanmo.domain.enums.MatchingType;
+
+@Getter
+@AllArgsConstructor
+public class QueueInfoResponseDto {
+    private MatchingType matchingType;
+    private GenderMatchingType genderMatchingType;
+    private long waitingCount;
+}

--- a/src/main/java/org/example/hanmo/service/AdminService.java
+++ b/src/main/java/org/example/hanmo/service/AdminService.java
@@ -3,6 +3,7 @@ package org.example.hanmo.service;
 import org.example.hanmo.domain.enums.UserRole;
 import org.example.hanmo.dto.admin.date.DashboardSignUpDto;
 import org.example.hanmo.dto.admin.date.DashboardGroupDto;
+import org.example.hanmo.dto.admin.date.QueueInfoResponseDto;
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
 import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
 
@@ -21,4 +22,5 @@ public interface AdminService {
 
     void changeUserRole(String tempToken, Long userId, UserRole newRole);
 
+    List<QueueInfoResponseDto> getQueueStatuses(String tempToken);
 }

--- a/src/main/java/org/example/hanmo/service/MatchingService.java
+++ b/src/main/java/org/example/hanmo/service/MatchingService.java
@@ -3,6 +3,7 @@ package org.example.hanmo.service;
 import java.util.List;
 
 import org.example.hanmo.domain.UserEntity;
+import org.example.hanmo.dto.admin.date.QueueInfoResponseDto;
 import org.example.hanmo.dto.matching.request.RedisUserDto;
 import org.example.hanmo.dto.matching.response.MatchingResponse;
 import org.example.hanmo.dto.matching.response.MatchingResultResponse;
@@ -44,4 +45,5 @@ public interface MatchingService {
   void cancelMatching(String tempToken);
 
   void cleanupAfterUserDeletion(String nickname);
+
 }

--- a/src/main/java/org/example/hanmo/service/impl/AdminServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/AdminServiceImpl.java
@@ -7,12 +7,13 @@ import org.example.hanmo.domain.enums.GroupStatus;
 import org.example.hanmo.domain.enums.UserRole;
 import org.example.hanmo.dto.admin.date.DashboardSignUpDto;
 import org.example.hanmo.dto.admin.date.DashboardGroupDto;
+import org.example.hanmo.dto.admin.date.QueueInfoResponseDto;
 import org.example.hanmo.dto.admin.request.AdminRequestDto;
 import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
 import org.example.hanmo.error.ErrorCode;
 import org.example.hanmo.error.exception.BadRequestException;
-import org.example.hanmo.error.exception.NotFoundException;
 import org.example.hanmo.redis.RedisTempRepository;
+import org.example.hanmo.redis.RedisWaitingRepository;
 import org.example.hanmo.repository.MatchingGroupRepository;
 import org.example.hanmo.repository.user.UserRepository;
 import org.example.hanmo.service.AdminService;
@@ -38,6 +39,7 @@ public class AdminServiceImpl implements AdminService {
     private final RedisTempRepository redisTempRepository;
     private final MatchingService matchingService;
     private final MatchingGroupRepository matchingGroupRepository;
+    private final RedisWaitingRepository redisWaitingRepository;
     private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
 
     @Override
@@ -115,5 +117,11 @@ public class AdminServiceImpl implements AdminService {
         UserEntity target = UserValidate.getUserById(userId, userRepository);
         target.setUserRole(newRole);
         userRepository.save(target);
+    }
+
+    @Override
+    public List<QueueInfoResponseDto> getQueueStatuses(String tempToken) {
+        adminValidate.verifyAdmin(tempToken);
+        return redisWaitingRepository.getQueueStatuses();
     }
 }

--- a/src/main/java/org/example/hanmo/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/MatchingServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.example.hanmo.domain.MatchingGroupsEntity;
 import org.example.hanmo.domain.UserEntity;
 import org.example.hanmo.domain.enums.*;
+import org.example.hanmo.dto.admin.date.QueueInfoResponseDto;
 import org.example.hanmo.dto.matching.request.RedisUserDto;
 import org.example.hanmo.dto.matching.response.MatchingResponse;
 import org.example.hanmo.dto.matching.response.MatchingResultResponse;
@@ -20,6 +21,7 @@ import org.example.hanmo.redis.RedisWaitingRepository;
 import org.example.hanmo.repository.MatchingGroupRepository;
 import org.example.hanmo.repository.user.UserRepository;
 import org.example.hanmo.service.MatchingService;
+import org.example.hanmo.vaildate.AdminValidate;
 import org.example.hanmo.vaildate.AuthValidate;
 import org.example.hanmo.vaildate.UserValidate;
 import org.jetbrains.annotations.NotNull;
@@ -40,6 +42,7 @@ public class MatchingServiceImpl implements MatchingService {
   private final AuthValidate authValidate;
   private final StringRedisTemplate stringRedisTemplate;
   private final UserValidate userValidate;
+  private final AdminValidate adminValidate;
 
   // 쿨다운 키를 하루로 지정
   private static final Duration COOLDOWN_DURATION = Duration.ofDays(1);
@@ -535,4 +538,5 @@ public class MatchingServiceImpl implements MatchingService {
     userRepository.saveAll(others);
     matchingGroupRepository.delete(group);
   }
+
 }


### PR DESCRIPTION
Redis 내부의 매칭 대기 상태를 확인 가능합니다. que스택을 이용해서 구현 했고, 타입별로 확인 가능합니다.