### PR TITLE
Feature/chatting

### DIFF
--- a/src/main/java/org/example/hanmo/controller/AdminController.java
+++ b/src/main/java/org/example/hanmo/controller/AdminController.java
@@ -3,6 +3,7 @@ package org.example.hanmo.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.example.hanmo.domain.enums.UserStatus;
 import org.example.hanmo.dto.admin.date.DashboardSignUpDto;
 import org.example.hanmo.dto.admin.date.DashboardGroupDto;
 import org.example.hanmo.dto.admin.date.QueueInfoResponseDto;
@@ -53,10 +54,11 @@ public class AdminController {
     @GetMapping("/search")
     public ResponseEntity<PageResponseDto<AdminUserResponseDto>> searchUsers(
             @RequestParam(value = "keyword", required = false, defaultValue = "") String keyword,
+            @RequestParam(value = "status", required = false) UserStatus status,
             @RequestParam(value = "page", defaultValue = "0") int page
     ) {
         Pageable pageable = PageRequest.of(page, 30);
-        var userPage = adminService.searchUsersByNickname( keyword, pageable);
+        var userPage = adminService.searchUsersByNickname( keyword,status, pageable);
         return ResponseEntity.ok(PageResponseDto.from(userPage));
     }
 

--- a/src/main/java/org/example/hanmo/controller/AdminController.java
+++ b/src/main/java/org/example/hanmo/controller/AdminController.java
@@ -42,6 +42,13 @@ public class AdminController {
         return ResponseEntity.ok().header("tempToken", tempToken).body("관리자 로그인 되었습니다.");
     }
 
+    @Operation(summary = "상태값 초기화", tags = {"관리자 기능"})
+    @PatchMapping("/reset-matching/{userId}")
+    public ResponseEntity<String> resetUserMatchingInfo(@PathVariable Long userId) {
+        adminService.resetUserMatchingInfo(userId);
+        return ResponseEntity.ok(userId+"번 유저의 상태가 초기화되었습니다.");
+    }
+
     @Operation(summary = "닉네임·이름으로 사용자 검색 (페이지당 30개)", tags = {"관리자 기능"})
     @GetMapping("/search")
     public ResponseEntity<PageResponseDto<AdminUserResponseDto>> searchUsers(
@@ -52,6 +59,8 @@ public class AdminController {
         var userPage = adminService.searchUsersByNickname( keyword, pageable);
         return ResponseEntity.ok(PageResponseDto.from(userPage));
     }
+
+
 
     @Operation(summary = "닉네임으로 사용자 삭제 (관리자)",tags = {"관리자 기능"})
     @DeleteMapping("/{nickname}")

--- a/src/main/java/org/example/hanmo/dto/admin/response/AdminUserResponseDto.java
+++ b/src/main/java/org/example/hanmo/dto/admin/response/AdminUserResponseDto.java
@@ -15,6 +15,8 @@ public class AdminUserResponseDto {
     private String phoneNumber;
     private String instagramId;
     private String userRole;
+    private String gender;
+    private String matchingGenderType;
     private UserStatus userStatus;
     private Long matchingGroupId;
     private MatchingType matchingType;

--- a/src/main/java/org/example/hanmo/redis/RedisWaitingRepository.java
+++ b/src/main/java/org/example/hanmo/redis/RedisWaitingRepository.java
@@ -77,4 +77,20 @@ public class RedisWaitingRepository {
     }
     return list;
   }
+
+  //위에 삭제키가 있지만, 레디스 dto를 받아와 생성자를 다시 만들어야하는 번거로움이 있어 추가합니다. - 축제 이후 삭제예정
+  public void removeUserById(Long userId) {
+    for (MatchingType mt : MatchingType.values()) {
+      for (GenderMatchingType gt : GenderMatchingType.values()) {
+        String key = getKey(mt, gt);
+        List<RedisUserDto> list = redisUserTemplate.opsForList().range(key, 0, -1);
+        if (list == null) continue;
+
+        list.stream()
+                .filter(dto -> dto.getId().equals(userId))
+                .findFirst()
+                .ifPresent(dto -> redisUserTemplate.opsForList().remove(key, 1, dto));
+      }
+    }
+  }
 }

--- a/src/main/java/org/example/hanmo/repository/user/UserRepositoryCustom.java
+++ b/src/main/java/org/example/hanmo/repository/user/UserRepositoryCustom.java
@@ -1,5 +1,6 @@
 package org.example.hanmo.repository.user;
 
+import org.example.hanmo.domain.enums.UserStatus;
 import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -7,5 +8,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface UserRepositoryCustom {
 
-    Page<AdminUserResponseDto> searchUsersByKeyword(String keyword, Pageable pageable);
+    Page<AdminUserResponseDto> searchUsersByKeyword(String keyword, UserStatus userStatus, Pageable pageable);
 }

--- a/src/main/java/org/example/hanmo/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/org/example/hanmo/repository/user/UserRepositoryImpl.java
@@ -33,6 +33,8 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                         u.phoneNumber,
                         u.instagramId,
                         u.userRole.stringValue(),
+                        u.gender.stringValue(),
+                        u.genderMatchingType.stringValue(),
                         u.userStatus,
                         u.matchingGroup.matchingGroupId,
                         u.matchingType

--- a/src/main/java/org/example/hanmo/service/AdminService.java
+++ b/src/main/java/org/example/hanmo/service/AdminService.java
@@ -1,6 +1,7 @@
 package org.example.hanmo.service;
 
 import org.example.hanmo.domain.enums.UserRole;
+import org.example.hanmo.domain.enums.UserStatus;
 import org.example.hanmo.dto.admin.date.DashboardSignUpDto;
 import org.example.hanmo.dto.admin.date.DashboardGroupDto;
 import org.example.hanmo.dto.admin.date.QueueInfoResponseDto;
@@ -17,7 +18,7 @@ public interface AdminService {
     void resetUserMatchingInfo(Long userId);
     String loginAdmin(AdminRequestDto requestDto);
     void addAdminInfo(AdminRequestDto dto);
-    Page<AdminUserResponseDto> searchUsersByNickname(String keyword, Pageable pageable);
+    Page<AdminUserResponseDto> searchUsersByNickname(String keyword, UserStatus status, Pageable pageable);
     void deleteUserByNickname(String nickname);
     DashboardGroupDto getDashboardStats();
     DashboardSignUpDto getTodaySignupStats();

--- a/src/main/java/org/example/hanmo/service/AdminService.java
+++ b/src/main/java/org/example/hanmo/service/AdminService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface AdminService {
+    void resetUserMatchingInfo(Long userId);
     String loginAdmin(AdminRequestDto requestDto);
     void addAdminInfo(AdminRequestDto dto);
     Page<AdminUserResponseDto> searchUsersByNickname(String keyword, Pageable pageable);

--- a/src/main/java/org/example/hanmo/service/impl/AdminServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/AdminServiceImpl.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.example.hanmo.aop.AdminCheck;
 import org.example.hanmo.domain.UserEntity;
+import org.example.hanmo.domain.enums.GenderMatchingType;
 import org.example.hanmo.domain.enums.GroupStatus;
+import org.example.hanmo.domain.enums.MatchingType;
 import org.example.hanmo.domain.enums.UserRole;
 import org.example.hanmo.dto.admin.date.DashboardSignUpDto;
 import org.example.hanmo.dto.admin.date.DashboardGroupDto;
@@ -13,6 +15,7 @@ import org.example.hanmo.dto.admin.request.AdminRequestDto;
 import org.example.hanmo.dto.admin.request.ManualMatchRequestDto;
 import org.example.hanmo.dto.admin.response.AdminMatchingResponseDto;
 import org.example.hanmo.dto.admin.response.AdminUserResponseDto;
+import org.example.hanmo.dto.matching.request.RedisUserDto;
 import org.example.hanmo.error.ErrorCode;
 import org.example.hanmo.error.exception.BadRequestException;
 import org.example.hanmo.redis.RedisTempRepository;
@@ -46,6 +49,21 @@ public class AdminServiceImpl implements AdminService {
     private final MatchingGroupRepository matchingGroupRepository;
     private final RedisWaitingRepository redisWaitingRepository;
     private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    @Override
+    @AdminCheck
+    public void resetUserMatchingInfo(Long userId) {
+        redisWaitingRepository.removeUserById(userId);
+        UserEntity user = UserValidate.getUserById(userId, userRepository);
+
+        user.setUserStatus(null);
+        user.setMatchingType(null);
+        user.setGenderMatchingType(null);
+        user.setMatchingGroup(null);
+
+        userRepository.save(user);
+    }
+
     @Override
     public String loginAdmin(AdminRequestDto dto) {
         UserEntity admin=adminValidate.validateAdminLogin(dto.getPhoneNumber(), dto.getLoginId(), dto.getLoginPw());

--- a/src/main/java/org/example/hanmo/service/impl/AdminServiceImpl.java
+++ b/src/main/java/org/example/hanmo/service/impl/AdminServiceImpl.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.example.hanmo.aop.AdminCheck;
 import org.example.hanmo.domain.UserEntity;
-import org.example.hanmo.domain.enums.GenderMatchingType;
-import org.example.hanmo.domain.enums.GroupStatus;
-import org.example.hanmo.domain.enums.MatchingType;
-import org.example.hanmo.domain.enums.UserRole;
+import org.example.hanmo.domain.enums.*;
 import org.example.hanmo.dto.admin.date.DashboardSignUpDto;
 import org.example.hanmo.dto.admin.date.DashboardGroupDto;
 import org.example.hanmo.dto.admin.date.QueueInfoResponseDto;
@@ -97,8 +94,8 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     @AdminCheck
-    public Page<AdminUserResponseDto> searchUsersByNickname(String keyword, Pageable pageable) {
-        return userRepository.searchUsersByKeyword(keyword, pageable);
+    public Page<AdminUserResponseDto> searchUsersByNickname(String keyword, UserStatus userStatus, Pageable pageable) {
+        return userRepository.searchUsersByKeyword(keyword, userStatus ,pageable);
     }
 
     @Override


### PR DESCRIPTION
1. 어드민, 유저 조회에 매칭타입, 성별, 매칭 성별타입 추가
2. 상태값별 PENDING, MATCHED 등별로 조회 가능 
3. RedisDTO 경량화 
이전 키값 비교 
// 변경 전
{"@class":"org.example.hanmo.dto.matching.request.RedisUserDto","id":3,"name":"User3","phoneNumber":null,"nickname":null,"instagramId":null,"studentNumber":null,"nicknameChanged":null,"userStatus":"PENDING","department":3,"mbti":null,"matchingType":null,"genderMatchingType":null,"gender":1,"matchingGroupId":null}

// 변경 후
{"id":3,"name":"User3","userStatus":"PENDING","department":3,"gender":1}

null값 제외로 80% 축소 
